### PR TITLE
Simplified and sped up core function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
 'use strict';
 
-var toStr = Object.prototype.toString;
-var fnToStr = Function.prototype.toString;
-var isFnRegex = /^\s*(?:function)?\*/;
+var GeneratorFunction = (function* () {}).constructor;
 
 module.exports = function isGeneratorFunction(fn) {
-	if (typeof fn !== 'function') { return false; }
-	var fnStr = toStr.call(fn);
-	return (fnStr === '[object Function]' || fnStr === '[object GeneratorFunction]') && isFnRegex.test(fnToStr.call(fn));
+    return (fn instanceof GeneratorFunction);
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var GeneratorFunction = (function* () {}).constructor;
+var GeneratorFunction = (function * () {}).constructor;
 
 module.exports = function isGeneratorFunction(fn) {
     return (fn instanceof GeneratorFunction);

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,14 +1,14 @@
-const oldCheck = require("./benchmark/old");
-const newCheck = require("./benchmark/new");
+var oldCheck = require('./benchmark/old');
+var newCheck = require('./benchmark/new');
 
-const hrtimeToMilliseconds = function (hrtime) {
+var hrtimeToMilliseconds = function (hrtime) {
     return (hrtime[0] * 1000) + (hrtime[1] / 1000000.0);
 };
 
-const runBenchmark = function (check, fn) {
-    const start = process.hrtime();
+var runBenchmark = function (check, fn) {
+    var start = process.hrtime();
 
-    const acc = [];
+    var acc = [];
     for (let i = 0; i < 1000000; i++) {
         acc.push(check(fn));
     }
@@ -16,6 +16,6 @@ const runBenchmark = function (check, fn) {
     return hrtimeToMilliseconds(process.hrtime(start));
 };
 
-const fn = function* () {};
+var fn = function * () {};
 console.log(`new time: ${ runBenchmark(newCheck, fn) }ms`);
 console.log(`old time: ${ runBenchmark(oldCheck, fn) }ms`);

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,21 @@
+const oldCheck = require("./benchmark/old");
+const newCheck = require("./benchmark/new");
+
+const hrtimeToMilliseconds = function (hrtime) {
+    return (hrtime[0] * 1000) + (hrtime[1] / 1000000.0);
+};
+
+const runBenchmark = function (check, fn) {
+    const start = process.hrtime();
+
+    const acc = [];
+    for (let i = 0; i < 1000000; i++) {
+        acc.push(check(fn));
+    }
+
+    return hrtimeToMilliseconds(process.hrtime(start));
+};
+
+const fn = function* () {};
+console.log(`new time: ${ runBenchmark(newCheck, fn) }ms`);
+console.log(`old time: ${ runBenchmark(oldCheck, fn) }ms`);

--- a/test/benchmark/new.js
+++ b/test/benchmark/new.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var GeneratorFunction = (function* () {}).constructor;
+
+module.exports = function isGeneratorFunction(fn) {
+    return (fn instanceof GeneratorFunction);
+};

--- a/test/benchmark/old.js
+++ b/test/benchmark/old.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var toStr = Object.prototype.toString;
+var fnToStr = Function.prototype.toString;
+var isFnRegex = /^\s*(?:function)?\*/;
+
+module.exports = function isGeneratorFunction(fn) {
+	if (typeof fn !== 'function') { return false; }
+	var fnStr = toStr.call(fn);
+	return (fnStr === '[object Function]' || fnStr === '[object GeneratorFunction]') && isFnRegex.test(fnToStr.call(fn));
+};


### PR DESCRIPTION
I was able to simplify and speed up (around a 30-35x speed increase) the core function. All of the tests pass, and I have added a benchmark (albeit very simple one) to show the performance increase.

I did have an issue with getting the linter to run; it seems that eslint doesn't like the `function *` syntax, not sure exactly how to fix that, but I've tried to follow your style guidelines regardless.

Average benchmark on my machine: 

    new time: 27.280438ms
    old time: 920.650249ms